### PR TITLE
🐛 bug：fix copy file no find error in windows

### DIFF
--- a/packages/block-sdk/package.json
+++ b/packages/block-sdk/package.json
@@ -14,7 +14,7 @@
     "getnpmregistry": "^1.0.1",
     "git-url-parse": "^11.1.2",
     "mem-fs": "^1.1.3",
-    "mem-fs-editor-async": "^6.0.1",
+    "@umijs/mem-fs-editor": "^6.0.2",
     "ora": "3.4.0",
     "prettier": "1.18.2",
     "sort-package-json": "^1.22.1",

--- a/packages/block-sdk/src/addBlock.ts
+++ b/packages/block-sdk/src/addBlock.ts
@@ -113,23 +113,7 @@ export async function addBlock(args: AddBlockOption = {}, opts: AddBlockOption =
   const blockConfig: {
     npmClient?: string;
   } = userConfig?.block || {};
-  const addLogs = [];
-
-  const getSpinner = () => {
-    const spinner = ora();
-    return {
-      ...spinner,
-      succeed: (info?: string) => spinner.succeed(info),
-      start: info => {
-        spinner.start(info);
-        addLogs.push(info);
-      },
-      fail: (info?: string) => spinner.fail(info),
-      stopAndPersist: (option?: any) => spinner.stopAndPersist(option),
-    };
-  };
-
-  const spinner = getSpinner();
+  const spinner = ora();
 
   if (!opts.remoteLog) {
     opts.remoteLog = () => {};
@@ -222,7 +206,6 @@ export async function addBlock(args: AddBlockOption = {}, opts: AddBlockOption =
   // 4. install additional dependencies
   // check dependencies conflict and install dependencies
   // install
-  opts.remoteLog('📦  Install extra dependencies');
   spinner.start('📦  install dependencies package');
   await installDependencies(
     {
@@ -241,18 +224,19 @@ export async function addBlock(args: AddBlockOption = {}, opts: AddBlockOption =
   spinner.succeed();
 
   // 5. run generator
-  opts.remoteLog('🔥  Generate files');
   spinner.start('🔥  Generate files');
-  spinner.stopAndPersist();
   const { getBlockGenerator } = require('./getBlockGenerator');
   const BlockGenerator = getBlockGenerator(api);
+
   let isPageBlock = ctx.pkg.blockConfig && ctx.pkg.blockConfig.specVersion === '0.1';
+
   if (isPage !== undefined) {
     // when user use `umi block add --page`
     isPageBlock = isPage;
   }
   debug(`isPageBlock: ${isPageBlock}`);
   debug(`ctx.filePath: ${ctx.filePath}`);
+
   const generator = new BlockGenerator({
     name: args._ ? args._.slice(2) : [],
     args: {
@@ -396,6 +380,6 @@ export async function addBlock(args: AddBlockOption = {}, opts: AddBlockOption =
   return {
     generator,
     ctx,
-    logs: addLogs,
+    logs: [],
   };
 }

--- a/packages/block-sdk/src/appendBlockToContainer.ts
+++ b/packages/block-sdk/src/appendBlockToContainer.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { createDebug } from '@umijs/utils';
 import insertComponent from './sdk/insertComponent';
@@ -7,15 +7,20 @@ import { INSERT_BLOCK_PLACEHOLDER, UMI_UI_FLAG_PLACEHOLDER } from './sdk/constan
 
 const debug = createDebug('umiui:block-sdk:appendBlockToContainer');
 
-export const appendBlockToContainer = ({ entryPath, blockFolderName, dryRun, index, logger }) => {
+export const appendBlockToContainer = ({ entryPath, blockFolderName, dryRun, index }) => {
   debug('start to update the entry file for block(s) under the path...');
 
+  /**
+   * 获取地址
+   */
   const oldEntry = readFileSync(entryPath, 'utf-8');
   debug(`insert component ${blockFolderName} with index ${index}`);
   debug('entryPath', entryPath);
   debug('blockFolderName', blockFolderName);
+
   const blockPath = join(dirname(entryPath), blockFolderName);
   debug('blockPath', blockPath);
+
   const absolutePath =
     findJS({
       base: blockPath,
@@ -26,6 +31,7 @@ export const appendBlockToContainer = ({ entryPath, blockFolderName, dryRun, ind
       fileNameWithoutExt: 'index',
     });
   debug('absolutePath', absolutePath);
+
   const blockContent = readFileSync(absolutePath, 'utf-8');
 
   try {
@@ -43,6 +49,6 @@ export const appendBlockToContainer = ({ entryPath, blockFolderName, dryRun, ind
       writeFileSync(entryPath, newEntry);
     }
   } catch (e) {
-    logger.appendLog(`Failed write block component: ${e.message}\n`);
+    console.log(`Failed write block component: ${e.message}\n`);
   }
 };

--- a/packages/block-sdk/src/getBlockGenerator.ts
+++ b/packages/block-sdk/src/getBlockGenerator.ts
@@ -5,7 +5,7 @@ import upperCamelCase from 'uppercamelcase';
 import inquirer from 'inquirer';
 import { IApi } from '@umijs/types';
 import memFs from 'mem-fs';
-import editor from 'mem-fs-editor-async';
+import editor from '@umijs/mem-fs-editor';
 import { winPath, mkdirp, semver, Mustache, rimraf, createDebug, Generator } from '@umijs/utils';
 import replaceContent from './replaceContent';
 import { SINGULAR_SENSLTIVE } from './constants';
@@ -274,6 +274,7 @@ export const getBlockGenerator = (api: IApi) => {
       if (isEmptyFolder(targetPath)) {
         rimraf.sync(targetPath);
       }
+      console.log(targetPath);
       while (this.isPageBlock && existsSync(targetPath)) {
         if (this.execution === 'auto') {
           throw new Error(`path ${this.path} already exist, press input a new path for it`);
@@ -369,6 +370,7 @@ export const getBlockGenerator = (api: IApi) => {
           base: targetPath,
           fileNameWithoutExt: 'index',
         });
+
       debug('this.entryPath', this.entryPath);
       debug('targetPath', targetPath);
 
@@ -470,8 +472,9 @@ export const getBlockGenerator = (api: IApi) => {
               },
             });
             debug(`copy ${thePath} to ${realTarget}`);
+
             // eslint-disable-next-line no-await-in-loop
-            await this.fs.copy(winPath(thePath), winPath(realTarget), { process });
+            await this.fs.copyAsync(winPath(thePath), winPath(realTarget), { process });
           }
         }
       }

--- a/packages/block-sdk/src/getBlockGenerator.ts
+++ b/packages/block-sdk/src/getBlockGenerator.ts
@@ -274,7 +274,7 @@ export const getBlockGenerator = (api: IApi) => {
       if (isEmptyFolder(targetPath)) {
         rimraf.sync(targetPath);
       }
-      console.log(targetPath);
+
       while (this.isPageBlock && existsSync(targetPath)) {
         if (this.execution === 'auto') {
           throw new Error(`path ${this.path} already exist, press input a new path for it`);

--- a/packages/block-sdk/src/util.ts
+++ b/packages/block-sdk/src/util.ts
@@ -15,6 +15,7 @@ export interface IFindJSOpts {
   base: string;
   fileNameWithoutExt?: string;
 }
+
 export const findJS = (opts): string => {
   const { base, fileNameWithoutExt } = opts;
   let i = 0;
@@ -202,19 +203,7 @@ export const getBlockListFromGit = async (gitUrl, useBuiltJSON?) => {
  * @param {*} mySpinner
  */
 export async function gitUpdate(ctx, mySpinner) {
-  mySpinner.start('🚒  Git fetch');
-  try {
-    await execa('git', ['fetch'], {
-      cwd: ctx.templateTmpDirPath,
-      stdio: 'inherit',
-    });
-  } catch (e) {
-    mySpinner.fail();
-    throw new Error(e);
-  }
-  mySpinner.succeed();
-
-  mySpinner.start(`🚛  Git checkout ${ctx.branch}`);
+  mySpinner.start(`🚛  sync file for git repo --branch ${ctx.branch}`);
 
   try {
     await execa('git', ['checkout', ctx.branch], {
@@ -225,9 +214,17 @@ export async function gitUpdate(ctx, mySpinner) {
     mySpinner.fail();
     throw new Error(e);
   }
-  mySpinner.succeed();
 
-  mySpinner.start('🚀  Git pull');
+  try {
+    await execa('git', ['fetch'], {
+      cwd: ctx.templateTmpDirPath,
+      stdio: 'inherit',
+    });
+  } catch (e) {
+    mySpinner.fail();
+    throw new Error(e);
+  }
+
   try {
     await execa('git', ['pull'], {
       cwd: ctx.templateTmpDirPath,
@@ -236,9 +233,6 @@ export async function gitUpdate(ctx, mySpinner) {
     // 如果是 git pull 之后有了
     // git module 只能通过这种办法来初始化一下
     if (isSubmodule(ctx.templateTmpDirPath)) {
-      // 结束  git pull 的 spinner
-      mySpinner.succeed();
-
       // 如果是分支切换过来，可能没有初始化，初始化一下
       await execa('git', ['submodule', 'init'], {
         cwd: ctx.templateTmpDirPath,
@@ -246,7 +240,6 @@ export async function gitUpdate(ctx, mySpinner) {
         stdio: 'inherit',
       });
 
-      mySpinner.start('👀  update submodule');
       await execa('git', ['submodule', 'update', '--recursive'], {
         cwd: ctx.templateTmpDirPath,
         stdio: 'inherit',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3863,6 +3863,24 @@
     debug "^4.1.1"
     user-home "^2.0.0"
 
+"@umijs/mem-fs-editor@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@umijs/mem-fs-editor/-/mem-fs-editor-6.0.2.tgz#1beeb03b529839bdb250f6ebf60ae122ea90c206"
+  integrity sha512-wGKHe4yyJc1CarRKAtvYrUc6zRf0jLANBN4HU+5ZkuSIR7xLDH51oHsZMjuxXqli6STe5ommYXnojXSXZ7NBRg==
+  dependencies:
+    commondir "^1.0.1"
+    deep-extend "^0.6.0"
+    ejs "^2.6.1"
+    glob "^7.1.4"
+    globby "^10.0.0"
+    isbinaryfile "^4.0.0"
+    mkdirp "^1.0.0"
+    multimatch "^4.0.0"
+    rimraf "^3.0.0"
+    slash2 "^2.0.0"
+    through2 "^3.0.1"
+    vinyl "^2.2.0"
+
 "@umijs/plugin-access@2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@umijs/plugin-access/-/plugin-access-2.2.1.tgz#eb5493bed1ed8ddebdcb178885439b2884db8aa8"
@@ -12853,23 +12871,6 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-mem-fs-editor-async@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/mem-fs-editor-async/-/mem-fs-editor-async-6.0.1.tgz#388f4525bb8013c99f30d42e1aae1926812d6395"
-  integrity sha512-ltiukcw/7wWr0K9Pt6Ztgxalj8GWj/v65/DTOI9ql+m8NtgCma4qva9HpyfQLAPnj/XW0uGbrcM++fQor/IedQ==
-  dependencies:
-    commondir "^1.0.1"
-    deep-extend "^0.6.0"
-    ejs "^2.6.1"
-    glob "^7.1.4"
-    globby "^10.0.0"
-    isbinaryfile "^4.0.0"
-    mkdirp "^1.0.0"
-    multimatch "^4.0.0"
-    rimraf "^3.0.0"
-    through2 "^3.0.1"
-    vinyl "^2.2.0"
-
 mem-fs@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/mem-fs/-/mem-fs-1.1.3.tgz#b8ae8d2e3fcb6f5d3f9165c12d4551a065d989cc"
@@ -19313,6 +19314,14 @@ tmpl@1.0.x:
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
   integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
 
+tnpm-sync@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npm.taobao.org/tnpm-sync/download/tnpm-sync-1.0.1.tgz#096edf82fa38adb8ba06bcbb86b54b51b31e48e3"
+  integrity sha1-CW7fgvo4rbi6Bry7hrVLUbMeSOM=
+  dependencies:
+    execa "^4.0.0"
+    yargs-parser "^18.1.2"
+
 to-absolute-glob@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz#1865f43d9e74b0822db9f145b78cff7d0f7c849b"
@@ -20884,6 +20893,14 @@ yargs-parser@^15.0.1:
   version "15.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
   integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^18.1.2:
+  version "18.1.2"
+  resolved "https://registry.npm.taobao.org/yargs-parser/download/yargs-parser-18.1.2.tgz?cache=0&sync_timestamp=1585243543699&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs-parser%2Fdownload%2Fyargs-parser-18.1.2.tgz#2f482bea2136dbde0861683abea7756d30b504f1"
+  integrity sha1-L0gr6iE2294IYWg6vqd1bTC1BPE=
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"


### PR DESCRIPTION
close https://github.com/ant-design/ant-design-pro/issues/6235
close https://github.com/umijs/umi-ui/issues/39
close https://github.com/ant-design/ant-design-pro/issues/6206

## 问题描述

这个 [mem-fs-editor-async](https://github.com/ycjcl868/mem-fs-editor/commit/b268ed9910eeb11a6eb0fdfd4e4581c2940de25c)对windows 的支持不够好，导致 copy 的时候找不到文件

区块路径会转化为 `github.com/ant-design/pro-blocks/UserLogin/src/components/**` 会用 glob 进行查询，我们umi ui 中做了 winPath, 但是在  [utli](https://github.com/ycjcl868/mem-fs-editor/blob/b268ed9910eeb11a6eb0fdfd4e4581c2940de25c/lib/util.js) 中的
```
if (fsStats.isDirectory()) {
    return path.join(filePath, '**');
  }
```
join 之后就增加了平台相关的 "\\", 导致在 windows  无法找到任何文件。



### 解决方案

由于作者已经很久没有更新，我自己fork了一份仓库，完善了windows 的支持，增加了 ci

https://github.com/chenshuai2144/mem-fs-editor

https://github.com/chenshuai2144/mem-fs-editor/runs/549632491



