### PR TITLE
fix: theme ui build

### DIFF
--- a/packages/ui-builder/index.js
+++ b/packages/ui-builder/index.js
@@ -80,9 +80,7 @@ module.exports = opts => {
             {
               loader: require.resolve('less-loader'),
               options: {
-                modifyVars: {
-                  '@primary-color': 'red',
-                },
+                modifyVars: dark,
                 javascriptEnabled: true,
               },
             },

--- a/packages/ui-builder/index.js
+++ b/packages/ui-builder/index.js
@@ -1,4 +1,5 @@
 const TerserPlugin = require('terser-webpack-plugin');
+const { dark } = require('@umijs/ui-theme');
 const terserOptions = require('./terser');
 
 module.exports = opts => {

--- a/packages/ui-builder/package.json
+++ b/packages/ui-builder/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@umijs/babel-preset-umi": "3.0.14",
     "babel-loader": "8.0.6",
+    "@umijs/ui-theme": "1.0.1-beta.1",
     "css-loader": "3.4.2",
     "less": "3.11.1",
     "less-loader": "5.0.0",


### PR DESCRIPTION
让 插件编译的时候，less 主题和 Umi UI 的主题一致，变量也不会报错。